### PR TITLE
sparse 0.19.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v {{ ignore_tests }} --pyargs sparse.tests
+    - pytest -vv {{ ignore_tests }} --pyargs sparse.tests
 
 about:
   home: https://sparse.pydata.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,8 @@
 {% set name = "sparse" %}
 {% set version = "0.19.1" %}
-{% set ignore_tests = " --ignore=mlir_backend/tests" %}
 
-# E   ModuleNotFoundError: No module named 'mlir_finch'
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
@@ -30,18 +28,21 @@ requirements:
     - finch-tensor >=0.2.13
     - finch-mlir >=0.0.2
 
+# E   ModuleNotFoundError: No module named 'mlir_finch'
+{% set ignore_tests = " --ignore=mlir_backend/tests" %}
+
 test:
   imports:
     - sparse
   requires:
     - pip
-    - pytest >=3.5
     - dask
     - scipy
+    - pytest >=3.5
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -vv {{ ignore_tests }} --pyargs sparse.tests
+    - pytest -v {{ ignore_tests }} --pyargs sparse.tests
 
 about:
   home: https://sparse.pydata.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,15 @@
 {% set name = "sparse" %}
-{% set version = "0.19.0" %}
+{% set version = "0.19.1" %}
+{% set ignore_tests = " --ignore=mlir_backend/tests" %}
 
+# E   ModuleNotFoundError: No module named 'mlir_finch'
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a95a52c63b45e2071df014d3f60080d36d160288131533a3b844021450677430
+  sha256: 159b5a2598b0cf0f94cfa417a72dddb5dcee2120b4405717456d8701c0d006ae
 
 build:
   number: 0
@@ -27,9 +29,6 @@ requirements:
   run_constrained:
     - finch-tensor >=0.2.13
     - finch-mlir >=0.0.2
-
-# E   ModuleNotFoundError: No module named 'mlir_finch'
-{% set ignore_tests = " --ignore=mlir_backend/tests" %}
 
 test:
   imports:


### PR DESCRIPTION
## Links
- Jira: https://anaconda.atlassian.net/browse/PKG-17010
- Dev URL: https://github.com/pydata/sparse
- PyPI: https://pypi.org/project/sparse/0.19.1/
- PyPI Inspector: https://inspector.pypi.io/project/sparse/0.19.1/

Bump `sparse` 0.17.0 → 0.19.1. Bumped Python floor to `skip py<311` (upstream now requires Python ≥3.11) and `finch-tensor >=0.2.13` in `run_constrained` (matches upstream's optional `finch` extra).